### PR TITLE
refactor: replace deprecated json filter with toJson

### DIFF
--- a/src/main/resources/whatsapp-template.peb
+++ b/src/main/resources/whatsapp-template.peb
@@ -6,7 +6,7 @@
         "profile": {
           "name": "{{profileName}}"
         },
-        "wa_id": {{ contact | json }}
+        "wa_id": {{ contact | toJson }}
       }
     {% endfor %}
     {% endif %}

--- a/src/test/resources/flows/common/main-flow-that-fails.yaml
+++ b/src/test/resources/flows/common/main-flow-that-fails.yaml
@@ -2,4 +2,4 @@ id: main-flow-that-fails
 namespace: io.kestra.tests
 tasks:
   - id: failed
-    type: io.kestra.core.tasks.executions.Fail
+    type: io.kestra.plugin.core.execution.Fail


### PR DESCRIPTION
Swap the deprecated json filter for toJson in the template. Both work on 1.x.