### PR TITLE
fix(security): remediate OWASP/CWE audit findings (2026-06-30)

### DIFF
--- a/src/main/java/io/kestra/plugin/meta/messenger/MessengerTemplate.java
+++ b/src/main/java/io/kestra/plugin/meta/messenger/MessengerTemplate.java
@@ -38,7 +38,7 @@ public abstract class MessengerTemplate extends AbstractMetaConnection {
     @Schema(title = "Page Access Token", description = "Page access token with pages_messaging permission for the sender Page.")
     @NotNull
     @PluginProperty(group = "main", secret = true)
-    protected String accessToken;
+    protected Property<String> accessToken;
 
     @Schema(title = "Recipient PSIDs", description = "Page-scoped recipient IDs; at least one is required or the task fails.")
     @NotNull
@@ -69,7 +69,7 @@ public abstract class MessengerTemplate extends AbstractMetaConnection {
     @Override
     public VoidOutput run(RunContext runContext) throws Exception {
         final var rRecipientIds = runContext.render(this.recipientIds).asList(String.class);
-        final var rAccessToken = runContext.render(this.accessToken);
+        final var rAccessToken = runContext.render(this.accessToken).as(String.class).orElseThrow();
         final var rPageId = runContext.render(this.pageId);
         final var rMessagingType = runContext.render(this.messagingType).as(MessagingType.class).orElse(MessagingType.UPDATE);
         final var rUrl = runContext.render(this.url).as(String.class);
@@ -81,8 +81,8 @@ public abstract class MessengerTemplate extends AbstractMetaConnection {
         String apiUrl = rUrl
             .orElseGet(
                 () -> String.format(
-                    "https://graph.facebook.com/v23.0/%s/messages?access_token=%s",
-                    rPageId, rAccessToken
+                    "https://graph.facebook.com/v23.0/%s/messages",
+                    rPageId
                 )
             );
 
@@ -101,6 +101,7 @@ public abstract class MessengerTemplate extends AbstractMetaConnection {
 
                 HttpRequest request = createRequestBuilder(runContext)
                     .addHeader("Content-Type", "application/json")
+                    .addHeader("Authorization", "Bearer " + rAccessToken)
                     .uri(URI.create(apiUrl))
                     .method("POST")
                     .body(HttpRequest.StringRequestBody.builder().content(payload).build())


### PR DESCRIPTION
## Summary

Remediates all findings (CRITICAL/HIGH/MEDIUM/LOW) from the 2026-06-30 automated security audit against OWASP Top 10 (2025), CWE Top 25, and OWASP ASVS Level 1.

## Findings Fixed

- **HIGH** — Access token exposed as URL query parameter in MessengerTemplate — `src/main/java/io/kestra/plugin/meta/messenger/MessengerTemplate.java:84` — Moved the Facebook Messenger access token from the `?access_token=` URL query parameter to an `Authorization: Bearer <token>` HTTP header, matching the pattern already used in `facebook/posts/Create.java`, `Delete.java`, `GetInsights.java`, and `List.java`. Prevents the plaintext token from leaking into server access logs, proxy logs, or HTTP client debug output (CWE-598 / OWASP A02:2021 / ASVS 2.10.3).
- **MEDIUM** — `MessengerTemplate.accessToken` declared as plain `String` instead of `Property<String>` — `src/main/java/io/kestra/plugin/meta/messenger/MessengerTemplate.java:41` — Changed the field type to `Property<String>` and rendered it via `runContext.render(...).as(String.class)`, aligning with the Kestra plugin coding standard of using `Property<T>` for all task properties (enables proper Pebble expression rendering and consistent secret handling).

## Testing

- [ ] `./gradlew build` passes
- [ ] No regressions in existing tests

## References

- Security Audit EPIC: https://github.com/kestra-io/plugin-meta/issues/57
- [Full Audit Report](https://claude.ai/code/artifact/87ba8c38-c7ec-40ef-8d8e-384da1bfacf4)
- [Org-wide Security Meta-EPIC](https://github.com/kestra-io/kestra-ee/issues/9092)
